### PR TITLE
make it work with latest pillow-3.0.0

### DIFF
--- a/oblogout/__init__.py
+++ b/oblogout/__init__.py
@@ -148,7 +148,7 @@ class OpenboxLogout():
             self.logger.debug("Rendering Fade")
             # Convert Pixbuf to PIL Image
             wh = (pb.get_width(),pb.get_height())
-            pilimg = Image.fromstring("RGB", wh, pb.get_pixels())
+            pilimg = Image.frombytes("RGB", wh, pb.get_pixels())
 
             pilimg = pilimg.point(lambda p: (p * self.opacity) / 255 )
 


### PR DESCRIPTION
According to [1] Image.fromstring() method has been
deprecaed for a while and have now been removed. This
path replaces Image.fromstring() with Image.frombytes()
just as exception message says.

[1] http://pillow.readthedocs.org/en/3.0.x/releasenotes/3.0.0.html#deprecated-methods
